### PR TITLE
comaptibility changes for 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18.1
-	yarn_mappings=1.18.1+build.1
-	loader_version=0.12.10
+	minecraft_version=1.18.2
+	yarn_mappings=1.18.2+build.2
+	loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 2.1.0
+	mod_version = 2.1.1
 	maven_group = dev.micalobia
 	archives_base_name = micalibria
 
 # Dependencies
-	fabric_version=0.44.0+1.18
-	statement_version=4.2.1
+	fabric_version=0.47.10+1.18.2
+	statement_version=4.2.2

--- a/src/main/java/dev/micalobia/micalibria/item/ItemUtility.java
+++ b/src/main/java/dev/micalobia/micalibria/item/ItemUtility.java
@@ -32,7 +32,7 @@ public class ItemUtility {
 	}
 
 	public static BlockItem register(Block block, BlockItem item) {
-		if(Registry.ITEM.getEntries().stream().map(Entry::getValue).noneMatch(x -> x == item))
+		if(Registry.ITEM.getEntrySet().stream().map(Entry::getValue).noneMatch(x -> x == item))
 			Registry.register(Registry.ITEM, Registry.BLOCK.getId(block), item);
 		Item.BLOCK_ITEMS.put(block, item);
 		return item;

--- a/src/main/java/dev/micalobia/micalibria/mixin/VersionedMixinsPlugin.java
+++ b/src/main/java/dev/micalobia/micalibria/mixin/VersionedMixinsPlugin.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  * <br/>
  * <code>.1_16_3__. => After 1.16.3 (inclusive)<br/>
  * .__1_15_2. => Before 1.15.2 (inclusive)<br/>
- * .1_13__1_18_1. => Between 1.13.x and 1.18.1 (inclusive)</code>
+ * .1_13__1_18_1. => Between 1.13.x and 1.18.2 (inclusive)</code>
  */
 public class VersionedMixinsPlugin implements IMixinConfigPlugin {
 	private static final Pattern versionPattern =

--- a/src/main/java/dev/micalobia/micalibria/util/CommonTags.java
+++ b/src/main/java/dev/micalobia/micalibria/util/CommonTags.java
@@ -1,12 +1,12 @@
 package dev.micalobia.micalibria.util;
 
-import net.fabricmc.fabric.api.tag.TagFactory;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 
 public class CommonTags {
 	public static class Block {
-		public static final Tag<net.minecraft.block.Block> IMMOVABLE = TagFactory.BLOCK.create(new Identifier("c", "immovable"));
+		public static final TagKey<net.minecraft.block.Block> IMMOVABLE = TagKey.of(Registry.BLOCK_KEY, new Identifier("c", "immovable"));
 	}
 }

--- a/src/main/java/dev/micalobia/micalibria/util/nbt/serializers/NbtDeserializers.java
+++ b/src/main/java/dev/micalobia/micalibria/util/nbt/serializers/NbtDeserializers.java
@@ -22,7 +22,7 @@ public class NbtDeserializers {
 	@SuppressWarnings("unchecked")
 	public static final NbtDeserializer<JsonElement> JSON_ELEMENT = (nbt, context) -> {
 		switch(nbt.getType()) {
-			case NbtElement.NULL_TYPE:
+			case NbtElement.END_TYPE:
 				return JsonNull.INSTANCE;
 			case NbtElement.BYTE_TYPE:
 			case NbtElement.SHORT_TYPE:


### PR DESCRIPTION
changes to provide compatibility with 1.18.2
updated fabric api and fabric loader
switch to vanilla tags (TagFactory deprecated)